### PR TITLE
feat: add redis store

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.8'
+
+services:
+  redis:
+    image: redis:latest
+    restart: always
+    ports:
+      - '6777:6379'
+    volumes:
+      - "eval_store:/data"
+
+volumes:
+  eval_store:

--- a/index.ts
+++ b/index.ts
@@ -245,9 +245,7 @@ export class Evaluator {
       try {
         const isolate = new Isolate({
           memoryLimit: 8,
-          onCatastrophicError: (e) => {
-            reject(e);
-          }
+          onCatastrophicError: (e) => reject(e),
         });
 
         const result = await isolate
@@ -345,7 +343,7 @@ export class Evaluator {
                 ),
                 set: (key, data, ex, flag) => $1.apply(
                   undefined, 
-                  [__getKey(flag, $3), key, data], 
+                  [__getKey(flag, $3), key, typeof data === 'object' ? JSON.stringify(data) : data, ex], 
                   { result: { promise: true } }
                 ),
                 del: (key, flag) => $2.apply(
@@ -366,7 +364,7 @@ export class Evaluator {
               Object.freeze(global.p);
               `,
               [
-                new Reference(store.get), 
+                new Reference(store.get),
                 new Reference(store.set),
                 new Reference(store.del), 
                 new ExternalCopy(msg).copyInto(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "chalk": "^4.1.2",
         "express": "^4.19.2",
+        "ioredis": "^5.6.1",
         "ip": "^2.0.1",
         "isolated-vm": "^4.7.2",
         "moment-timezone": "^0.5.46",
@@ -43,6 +44,12 @@
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
@@ -352,6 +359,15 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
@@ -452,6 +468,15 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -803,6 +828,53 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
+    "node_modules/ioredis": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.6.1.tgz",
+      "integrity": "sha512-UxC0Yv1Y4WRJiGQxQkP0hfdL0/5/6YvdfOOClRgJ0qppSarkhneSa6UvkMkms0AkdGimSH3Ikqm+6mkMmX7vGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ioredis/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/ip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
@@ -837,6 +909,7 @@
       "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-4.7.2.tgz",
       "integrity": "sha512-JVEs5gzWObzZK5+OlBplCdYSpokMcdhLSs/xWYYxmYWVfOOFF4oZJsYh7E/FmfX8e7gMioXMpMMeEyX1afuKrg==",
       "hasInstallScript": true,
+      "license": "ISC",
       "dependencies": {
         "prebuild-install": "^7.1.1"
       },
@@ -848,6 +921,18 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
     },
     "node_modules/logform": {
       "version": "2.7.0",
@@ -1164,6 +1249,27 @@
         "node": ">= 6"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1389,6 +1495,12 @@
         "node": "*"
       }
     },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -1425,9 +1537,10 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
-      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -1507,9 +1620,10 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "simple server to run a vm for javascript evaluation",
   "main": "index.js",
   "scripts": {
-    "start": "tsc && node index.js",
+    "start": "docker-compose up -d && tsc && node index.js",
     "build": "tsc"
   },
   "author": "RyanPotat",
@@ -12,6 +12,7 @@
   "dependencies": {
     "chalk": "^4.1.2",
     "express": "^4.19.2",
+    "ioredis": "^5.6.1",
     "ip": "^2.0.1",
     "isolated-vm": "^4.7.2",
     "moment-timezone": "^0.5.46",

--- a/store/store.ts
+++ b/store/store.ts
@@ -131,7 +131,8 @@ const get = async (
   
 const set = async (
   privateKey: string,
-  key: string, data: unknown,
+  key: string,
+  data: unknown,
   expirySeconds: number,
 ): Promise<unknown | undefined> => {
   const len = await redis.hlen(key);
@@ -164,9 +165,14 @@ const ex = async (
   return redis.hexpire(privateKey, expiry, key, mode);
 };
 
+const len = async (privateKey: string): Promise<number> => {
+  return redis.hlen(privateKey);
+}
+
 export const store = {
   get,
   set,
   del,
+  len,
   ex,
 }

--- a/store/store.ts
+++ b/store/store.ts
@@ -96,19 +96,19 @@ class PotatStore {
     return this.#client.hlen(key);
   }
 
-  public async hexpire(key: string | Buffer, seconds: number, feild: string): Promise<unknown> {
+  public async hexpire(key: string | Buffer, seconds: number, field: string): Promise<unknown> {
     return this.#client.eval(
       `
         local key = KEYS[1]
         local seconds = ARGV[1]
-        local feild = ARGV[2]
-        local result = redis.call('HEXPIRE', key, seconds, feild)
+        local field = ARGV[2]
+        local result = redis.call('HEXPIRE', key, seconds, field)
         return result
       `,
       2,
       key,
       seconds,
-      feild,
+      field,
     )
   }
 }

--- a/store/store.ts
+++ b/store/store.ts
@@ -1,0 +1,171 @@
+import Redis from 'ioredis';
+import Logger from '../logger.js';
+
+const config = require('../config.json');
+
+class PotatStore {
+  #client: Redis;
+
+  #isReady = false;
+
+  get ready() {
+    return this.#isReady;
+  }
+
+  public constructor() {
+    this.#client = new Redis({
+      host: config.redisHost ?? 'localhost',
+      port: config.redisPort ?? 6379,
+    });
+
+    this.#client.on('close', (err) => {
+      this.#isReady = false;
+      Logger.error(`Redis Error: ${err}`);
+    });
+    this.#client.on('error', (err) => Logger.error(`Redis Error: ${err}`));
+    this.#client.on('ready', () => this.#isReady = true);
+
+    this.#client.once('ready', () => Logger.debug('Redis Connected'))
+  }
+
+  public async hset(
+    key: string | Buffer,
+    ...args: unknown[]
+  ): Promise<number> {
+    const stringifiedArgs = [];
+
+    for (const arg of args) {
+      if (typeof arg === 'string') {
+        stringifiedArgs.push(arg);
+
+        continue;
+      }
+
+      stringifiedArgs.push(JSON.stringify(arg));
+    }
+
+    return this.#client.hset(key, ...stringifiedArgs);
+  }
+
+  public async hdel(key: string | Buffer, ...fields: string[]): Promise<number> {
+    return this.#client.hdel(key, ...fields);
+  }
+
+  public async hmget<T = unknown>(
+    key: string | Buffer,
+    ...args: any[]
+  ): Promise<T[]> {
+    const data = await this.#client.hmget(key, ...args);
+    return data.map((d) => {
+      if (!d) {
+        return null;
+      }
+
+      try {
+        return JSON.parse(d as string)
+      } catch {
+        return d;
+      }
+    }).filter(t => t);
+  }
+
+  public async hgetall<T = unknown>(key: string | Buffer): Promise<Map<string, T>> {
+    const data = await this.#client.hgetall(key);
+    const out = new Map<string, T>();
+
+    for (const k in data) {
+      const value = data[k];
+      if (!value) {
+        continue;
+      }
+
+      let parsedValue: T;
+      try {
+        parsedValue = JSON.parse(value);
+      } catch {
+        parsedValue = value as T;
+      }
+
+      out.set(k, parsedValue);
+    }
+
+    return out;
+  }
+
+  public async hlen(key: string | Buffer): Promise<number> {
+    return this.#client.hlen(key);
+  }
+
+  public async hexpire(key: string | Buffer, seconds: number, feild: string): Promise<unknown> {
+    return this.#client.eval(
+      `
+        local key = KEYS[1]
+        local seconds = ARGV[1]
+        local feild = ARGV[2]
+        local result = redis.call('HEXPIRE', key, seconds, feild)
+        return result
+      `,
+      2,
+      key,
+      seconds,
+      feild,
+    )
+  }
+}
+
+const redis = new PotatStore();
+
+const MAX_KEYS = 100;
+
+const get = async (
+  privateKey: string,
+  key: string,
+): Promise<unknown | undefined> => {
+  const user = await redis.hmget(privateKey, key);
+  if (!user[0]) {
+    return undefined;
+  }
+
+  return user[0];
+};
+  
+const set = async (
+  privateKey: string,
+  key: string, data: unknown,
+  expiry: number,
+): Promise<unknown | undefined> => {
+  const len = await redis.hlen(key);
+  if (len > MAX_KEYS) {
+    throw new Error(`Too many keys in store: ${key}`);
+  }
+
+  await redis.hset(privateKey, key, data);
+
+  if (expiry > 0) {
+    ex(privateKey, key, expiry);
+  }
+
+  return get(privateKey, key);
+};
+
+const del = async (
+  privateKey: string,
+  key: string,
+): Promise<unknown | undefined> => {
+  return redis.hdel(privateKey, key);
+}
+
+const ex = async (
+  privateKey: string,
+  key: string,
+  expiry: number,
+): Promise<unknown | undefined> => {
+  return redis.hexpire(privateKey, expiry, key);
+};
+
+export const store = {
+  get,
+  set,
+  del,
+  ex,
+}


### PR DESCRIPTION
Adds Redis into the vm's API so users can store their own metadata. 

```typescript
  const someData = '1234';

  const ok = await store.set('data', someData);
  // Returns the value you just set - '1234'
  const data = await store.get('data');
  // '1234'
```

Adds permissions to the API allowing different combinations of storage based on context.

User only resolves to the user in the context, so yourself.
Channel only resolves to the channel in the context, wherever you're invoking.
Command only resolves to the command in the context, if applicable.

```typescript
  const permissions = {
    command: 1 << 1,
    user: 1 << 2,
    channel: 1 << 3,
  };

  const ok = await store.set('data', 'user-example', 0, permissions.user);
  // Returns the value you just set - 'user-example'
  const ok = await store.set('data', 'channel-example', 0, permissions.channel);
  // Returns the value you just set - 'channel-example'

  const userData = await store.get('data', permissions.user);
  // 'user-example'
  const channelData = await store.get('data', permissions.channel);
  // 'channel-example'

  // Bitwise:

  const ok = await store.set('data', 'user-channel-example', 0, permissions.channel | permissions.user)
  // Returns the value you just set - 'user-channel-example'

  const channelUserData = await store.get('data', permissionser.channel | permissions.user);
  // 'user-channel-example'

  // Aliases:

  store.set('data', true, permissions.channel | permissions.user, 0)
  s.s('data', true, p.ch | p.u, 0);
```

Closes #1